### PR TITLE
Reflect changes from cae-jenkins: Use URL_JENKINS instead of JENKINS_URL variable

### DIFF
--- a/jenkins.yml
+++ b/jenkins.yml
@@ -43,7 +43,7 @@ spec:
           value: "8087"
         - name: MICROSERVICE_PORT
           value: "8086"
-        - name: JENKINS_URL
+        - name: URL_JENKINS
           value: $(jenkins_url)
         - name: JENKINS_PREFIX
           value: $(jenkins_prefix)


### PR DESCRIPTION
This PR reflects the changes done in the cae-jenkins repository/container (see https://github.com/rwth-acis/cae-jenkins/pull/4).
The wiki entry was also updated accordingly.